### PR TITLE
docs(formik): fix typo

### DIFF
--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -416,7 +416,7 @@ const validate = values => {
 };
 ```
 
-- Asynchronous and return a Promise that's resolves to an object containing `errors`
+- Asynchronous and return a Promise that resolves to an object containing `errors`
 
 ```js
 // Async Validation


### PR DESCRIPTION
Fix a typo in the section about the `Formik` [validate property](https://formik.org/docs/api/formik#validate-values-values--formikerrorsvalues--promiseany).